### PR TITLE
Fix: Prevent JS error from special characters in child names

### DIFF
--- a/profile.html
+++ b/profile.html
@@ -197,7 +197,7 @@
                         childCard.className = 'list-group-item list-group-item-action flex-column align-items-start mb-2 shadow-sm border-left-primary'; // Added border-left
                         childCard.innerHTML = \`
                             <div class="d-flex w-100 justify-content-between">
-                                <h5 class="mb-1 h6"><a href="child_dashboard.html?child=\${encodeURIComponent(child.name)}">\${child.name}</a></h5>
+                                <h5 class="mb-1 h6"><a href="child_dashboard.html?child=${encodeURIComponent(child.name)}">${child.name.replace(/`/g, '&grave;')}</a></h5>
                                 <small>Age: \${child.age}</small>
                             </div>
                             <p class="mb-1"><small>Annual Gift Savings Contribution: $ \${(child.annualCashGiftToSavings || 0).toFixed(2)}</small></p>


### PR DESCRIPTION
Uncaught SyntaxError: Invalid or unexpected token (at profile.html:198:47)

The error was caused by unescaped backticks in child names when rendering the list of children in `profile.html`. This commit fixes the issue by replacing backticks with their HTML entity (`&grave;`) before inserting the child's name into the `innerHTML` of the child card.

This ensures that names containing special characters are displayed correctly and do not break the JavaScript template literal.